### PR TITLE
Fixes Chrome 21 bug with position of background-size in CSS file.

### DIFF
--- a/source/stylesheets/ui-progress-bar.css.scss
+++ b/source/stylesheets/ui-progress-bar.css.scss
@@ -118,10 +118,6 @@ $border-radius: $height;
     /* Adjust to your liking, and don't forget to adjust to the same amount in .ui-progress-bar */
     @include border-radius($border-radius);
     
-    /* Set the background size so the stripes work correctly */
-    -webkit-background-size: 44px 44px;
-    -moz-background-size: 36px 36px;
-    
     /* Webkit */
     /* For browser that don't support gradients, we'll set a base background colour */
     background-color: $bar-color;
@@ -146,6 +142,10 @@ $border-radius: $height;
       rgba(255,255,255,0) 15px, 
       rgba(255,255,255,0) 30px
     ), -moz-linear-gradient(rgba(white, 0.25) 0%, rgba(white, 0) 100%), $bar-color;
+
+    /* Set the background size so the stripes work correctly */
+    -webkit-background-size: 44px 44px;
+    -moz-background-size: 36px 36px;
     
     @include box-shadow(inset 0px 1px 0px 0px rgba(white, 0.4), inset 0px -1px 1px rgba(black, 0.2));
         


### PR DESCRIPTION
Saw this bug when I updated Chrome because we are using it on a development site as one of our major UI elements. Simply moving the background-size below the gradient declarations fixes this, I think something may have changed in WebKit where a gradient overrides any prior background declarations. Might also be fixed using the gradient as background-image and declaring all the other properties of the background separate, but this seemed like the best way to go about it.
