### PR TITLE
Fixed label stucked at "Completed"

### DIFF
--- a/source/javascripts/vendor/animated-progress.js
+++ b/source/javascripts/vendor/animated-progress.js
@@ -26,7 +26,7 @@
           }
           
           if (Math.ceil(progress) == 100) {
-            labelEl.text('Completed');
+            valueEl.text('Completed');
             setTimeout(function() {
               labelEl.fadeOut();
             }, 1000);


### PR DESCRIPTION
When playing the progress bar to 100% more than once. The label stayed at "Completed" as the .value element was remove by "labelEl.text()" @ line 29.
